### PR TITLE
Multiplayer Exceptions (#474)

### DIFF
--- a/src/Vlc.DotNet.Core.Interops/VlcMediaInstance.cs
+++ b/src/Vlc.DotNet.Core.Interops/VlcMediaInstance.cs
@@ -7,21 +7,22 @@ namespace Vlc.DotNet.Core.Interops
     public sealed class VlcMediaInstance : InteropObjectInstance
     {
         private readonly VlcManager myManager;
-
-        private static List<VlcMediaInstance> allInstances = new List<VlcMediaInstance>();
+        private static readonly Dictionary<IntPtr, VlcMediaInstance> AllInstances = new Dictionary<IntPtr, VlcMediaInstance>();
 
         public static VlcMediaInstance New(VlcManager manager, IntPtr pointer)
         {
-            var instance = allInstances.Find(delegate(VlcMediaInstance i)
+            lock (AllInstances)
             {
-                return i == pointer;
-            });
-            if (null == instance)
-            {
-                instance = new VlcMediaInstance(manager, pointer);
-                allInstances.Add(instance);
+                AllInstances.TryGetValue(pointer, out var instance);
+
+                if (null == instance)
+                {
+                    instance = new VlcMediaInstance(manager, pointer);
+                    AllInstances.Add(pointer, instance);
+                }
+
+                return instance;
             }
-            return instance;
         }
 
         private VlcMediaInstance(VlcManager manager, IntPtr pointer) : base(pointer)
@@ -31,7 +32,11 @@ namespace Vlc.DotNet.Core.Interops
 
         protected override void Dispose(bool disposing)
         {
-            allInstances.Remove(this);
+            lock (AllInstances)
+            {
+                AllInstances.Remove(this);
+            }
+            
             if (Pointer != IntPtr.Zero)
                 myManager.ReleaseMedia(this);
             base.Dispose(disposing);

--- a/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
+++ b/src/Vlc.DotNet.Core/VlcMediaPlayer/VlcMediaPlayer.cs
@@ -90,13 +90,7 @@ namespace Vlc.DotNet.Core
             if (IsPlaying())
                 Stop();
 
-            if (VlcMedia.LoadedMedias.ContainsKey(this))
-            foreach (var loadedMedia in VlcMedia.LoadedMedias[this])
-            {
-                loadedMedia.Dispose();
-            }
-            VlcMedia.LoadedMedias.Remove(this);
-
+            VlcMedia.RemoveAll(this);
             myMediaPlayerInstance.Dispose();
             Manager.Dispose();
         }


### PR DESCRIPTION
Lock access to "LoadedMedias", RegisterEvents and "allInstances" in order to make access to those resources, thread safe.

Fixes #430 and #464